### PR TITLE
Add default namespace

### DIFF
--- a/packages/client/src/Spacetime.ts
+++ b/packages/client/src/Spacetime.ts
@@ -35,12 +35,17 @@ export class Spacetime {
     )
   }
 
-  collection<T=any> (id: string): Collection<T> {
-    if (this.collections[id]) return this.collections[id]
-    const path = this.config.defaultNamespace ? `${this.config.defaultNamespace}/${id}` : id
-    const c = new Collection<T>(path, this.client)
-    this.collections[path] = c
+  collection<T=any> (path: string): Collection<T> {
+    const rp = this.getResolvedPath(path)
+    if (this.collections[rp]) return this.collections[rp]
+    const c = new Collection<T>(rp, this.client)
+    this.collections[rp] = c
     return c
+  }
+
+  private getResolvedPath = (path: string) => {
+    if (path.startsWith('/')) return path.substring(1)
+    return this.config.defaultNamespace ? `${this.config.defaultNamespace}/${path}` : path
   }
 
   private createCollection = async <T>(data: CollectionMeta): Promise<Collection<T>> => {

--- a/packages/client/src/__tests__/Spacetime.spec.ts
+++ b/packages/client/src/__tests__/Spacetime.spec.ts
@@ -31,35 +31,6 @@ test('collection is reused', () => {
   expect(s.collection('a')).toBe(a)
 })
 
-test('creates collection and returns it', async () => {
-  const s = new Spacetime({ sender, baseURL })
-  const meta: CollectionMeta = {
-    id: 'new',
-    code: `
-      collection Col {
-        id: string!;
-        name: string;
-      }
-    `,
-  }
-  const n = await s.createCollection(meta)
-
-  expect(sender).toHaveBeenCalledWith({
-    ...defaultRequest,
-    baseURL,
-    url: '/$collections/new',
-    method: 'POST',
-    data: {
-      data: meta,
-    },
-    headers: {
-      'X-Spacetime-Client': 'spacetime@ts/client:v0',
-    },
-  })
-
-  expect(n).toBeInstanceOf(Collection)
-})
-
 test('creates collections from schema in namespace', async () => {
   const s = new Spacetime({ sender, baseURL })
   const namespace = 'test'

--- a/packages/client/src/__tests__/Spacetime.spec.ts
+++ b/packages/client/src/__tests__/Spacetime.spec.ts
@@ -23,7 +23,12 @@ test('collection() returns collection', () => {
 
 test('collection() returns collection using default namespace', () => {
   const s = new Spacetime({ sender, defaultNamespace: 'hello-world' })
-  expect(s.collection('a').id).toBe('hello-world/a')
+  expect(s.collection('a/path').id).toBe('hello-world/a/path')
+})
+
+test('collection() returns collection using absolute path', () => {
+  const s = new Spacetime({ sender, defaultNamespace: 'hello-world' })
+  expect(s.collection('/a/path').id).toBe('a/path')
 })
 
 test('collection is reused', () => {

--- a/packages/client/src/__tests__/Spacetime.spec.ts
+++ b/packages/client/src/__tests__/Spacetime.spec.ts
@@ -1,7 +1,5 @@
-// import FakeTimers from '@sinonjs/fake-timers'
 import { Spacetime } from '../Spacetime'
 import { Collection } from '../Collection'
-import { CollectionMeta } from '../types'
 import { defaultRequest } from './util'
 
 // const clock = FakeTimers.install()

--- a/packages/client/src/__tests__/Spacetime.spec.ts
+++ b/packages/client/src/__tests__/Spacetime.spec.ts
@@ -21,6 +21,11 @@ test('collection() returns collection', () => {
   expect(s.collection('a')).toBeInstanceOf(Collection)
 })
 
+test('collection() returns collection using default namespace', () => {
+  const s = new Spacetime({ sender, defaultNamespace: 'hello-world' })
+  expect(s.collection('a').id).toBe('hello-world/a')
+})
+
 test('collection is reused', () => {
   const s = new Spacetime({
     sender,

--- a/packages/client/src/errors/constants.ts
+++ b/packages/client/src/errors/constants.ts
@@ -19,4 +19,5 @@ export const ERROR_REASONS: Record<string, { code?: keyof typeof ERROR_CODES, me
   'server-error': { code: 'internal', message: 'An internal error occured' },
   'request-cancelled': { message: 'Request was cancelled by the client' },
   'unknown-error': { message: 'Unexpected error received' },
+  'missing-namespace': { code: 'invalid-argument', message: 'Namespace is required' },
 }


### PR DESCRIPTION
Closes #2

Adding a default namespace:

```ts
new Spacetime({
  defaultNamespace: "hello-world"
})
```

This allows you to create collections without the prefix `.collections("People")`.

Making `createCollection()` private, to reduce API surface area.