### PR TITLE
Implement function calls on collections

### DIFF
--- a/packages/client/e2e/e2e.spec.ts
+++ b/packages/client/e2e/e2e.spec.ts
@@ -409,12 +409,7 @@ test('signing', async () => {
     name: 'Calum4',
   })
 
-  const callRes = await c.call('setNameWithAuth', [c.doc('id1'), 'Calum5'], pk)
-  expect(callRes).toEqual([{
-    $pk: pk,
-    id: 'id1',
-    name: 'Calum5',
-  }])
+  await c.call('setNameWithAuth', [c.doc('id1'), 'Calum5'], pk)
 
   const res3 = await c.doc('id1').get()
   expect(res3.data).toEqual({
@@ -445,11 +440,7 @@ test('call', async () => {
 
   await c.doc('id1').set({ name: 'Calum2' })
 
-  const callRes = await c.call('setName', [c.doc('id1'), 'Calum3'])
-  expect(callRes).toEqual([{
-    id: 'id1',
-    name: 'Calum3',
-  }])
+  await c.call('setName', [c.doc('id1'), 'Calum3'])
 
   const res = await c.doc('id1').get()
   expect(res.data).toEqual({

--- a/packages/client/e2e/e2e.spec.ts
+++ b/packages/client/e2e/e2e.spec.ts
@@ -21,7 +21,7 @@ const createCollection = async (s: Spacetime, namespace: string) => {
       }
 
       function setNameWithAuth(a: record, name: string) {
-        if (a.$pk != auth.publicKey) throw error('you do not own this record');
+        if (a.$pk != $auth.publicKey) throw error('you do not own this record');
 
         a.name = name;
       }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@spacetimexyz/eth": "^0.1.27",
-    "@spacetimexyz/parser": "^0.1.2",
+    "@spacetimexyz/parser": "0.1.3",
     "axios": "^0.27.2",
     "lodash.merge": "^4.6.2"
   }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@spacetimexyz/eth": "^0.1.27",
-    "@spacetimexyz/parser": "0.1.3",
+    "@spacetimexyz/parser": "0.1.4-beta2",
     "axios": "^0.27.2",
     "lodash.merge": "^4.6.2"
   }

--- a/packages/client/src/Collection.ts
+++ b/packages/client/src/Collection.ts
@@ -29,7 +29,7 @@ export class Collection<T> {
     try {
       if (this.meta) return this.meta
       const res = await this.client.request({
-        url: `/data/$collections/${encodeURIComponent(this.id)}`,
+        url: `/collections/$collections/records/${encodeURIComponent(this.id)}`,
         method: 'GET',
       }).send()
       this.meta = res.data?.data as CollectionMeta
@@ -70,7 +70,7 @@ export class Collection<T> {
 
   get = async (): Promise<CollectionList<T>> => {
     const res = await this.client.request({
-      url: `/data/${encodeURIComponent(this.id)}`,
+      url: `/collections/${encodeURIComponent(this.id)}/records`,
       method: 'GET',
     }).send()
 
@@ -118,7 +118,7 @@ export class Collection<T> {
     const changedArgs = eval(`${js.code}; const auth = ${JSON.stringify(auth)}; const args = ${JSON.stringify(resolvedArgs)}; f(auth, args); args`)
 
     await this.client.request({
-      url: `/call/${encodeURIComponent(this.id)}/${encodeURIComponent(functionName)}`,
+      url: `/collections/${encodeURIComponent(this.id)}/functions/${encodeURIComponent(functionName)}/call`,
       method: 'POST',
       data: {
         args: args.map(arg => {

--- a/packages/client/src/Collection.ts
+++ b/packages/client/src/Collection.ts
@@ -3,7 +3,7 @@ import { Query } from './Query'
 import { Subscription, SubscriptionFn, SubscriptionErrorFn } from './Subscription'
 import { Client } from './Client'
 import { BasicValue, CollectionMeta, CollectionDocument, CollectionList, QueryWhereOperator } from './types'
-import { parse, validateSet } from '@spacetimexyz/parser'
+import { generateJSFunction, parse, Program, validateSet } from '@spacetimexyz/parser'
 
 export class Collection<T> {
   id: string
@@ -29,7 +29,7 @@ export class Collection<T> {
     try {
       if (this.meta) return this.meta
       const res = await this.client.request({
-        url: `/$collections/${encodeURIComponent(this.id)}`,
+        url: `/data/$collections/${encodeURIComponent(this.id)}`,
         method: 'GET',
       }).send()
       this.meta = res.data?.data as CollectionMeta
@@ -40,6 +40,12 @@ export class Collection<T> {
     }
   }
 
+  private shortName = () => this.id.split('/').pop()
+
+  private collectionAST = (ast: Program) => {
+    return ast.nodes.find(c => c.Collection?.name === this.shortName())?.Collection
+  }
+
   private getValidator = async (): Promise<(data: Partial<T>) => Promise<boolean>> => {
     if (this.validator) return this.validator
 
@@ -47,7 +53,7 @@ export class Collection<T> {
     const ast = await parse(meta.code)
     this.validator = async (data: Partial<T>) => {
       try {
-        await validateSet(ast.nodes[0].Collection, data)
+        await validateSet(this.collectionAST(ast), data)
         return true
       } catch {
         return false
@@ -64,11 +70,69 @@ export class Collection<T> {
 
   get = async (): Promise<CollectionList<T>> => {
     const res = await this.client.request({
-      url: `/${encodeURIComponent(this.id)}`,
+      url: `/data/${encodeURIComponent(this.id)}`,
       method: 'GET',
     }).send()
 
     return res.data
+  }
+
+  call = async (functionName: string, args: (string | number | Doc<any>)[] = [], pk?: string): Promise<CollectionDocument<any>[]> => {
+    const meta = await this.getMeta()
+    const ast = await parse(meta.code)
+    const funcAST = this.collectionAST(ast).items.find((f: any) => f?.Function?.name === functionName)?.Function
+    if (!funcAST) throw new Error('Function not found')
+
+    for (const param in funcAST.parameters) {
+      const ourArg = args[param as any]
+      const expectedType = funcAST.parameters[param as any].type_
+      switch (expectedType) {
+        case 'String':
+          if (typeof ourArg !== 'string') throw new Error(`Argument ${param} must be a string`)
+          break
+        case 'Number':
+          if (typeof ourArg !== 'number') throw new Error(`Argument ${param} must be a number`)
+          break
+        case 'Record':
+          if (!(ourArg instanceof Doc)) throw new Error(`Argument ${param} must be a record`)
+          break
+      }
+    }
+
+    let resolvedArgs = []
+    for (const arg of args) {
+      if (arg instanceof Doc) {
+        resolvedArgs.push(arg.get().then(d => d.data))
+      } else {
+        resolvedArgs.push(arg)
+      }
+    }
+    resolvedArgs = await Promise.all(resolvedArgs)
+
+    const auth = {
+      publicKey: pk,
+    }
+
+    const js = await generateJSFunction(funcAST)
+    // eslint-disable-next-line no-eval
+    const changedArgs = eval(`${js.code}; const auth = ${JSON.stringify(auth)}; const args = ${JSON.stringify(resolvedArgs)}; f(auth, args); args`)
+
+    await this.client.request({
+      url: `/call/${encodeURIComponent(this.id)}/${encodeURIComponent(functionName)}`,
+      method: 'POST',
+      data: {
+        args: args.map(arg => {
+          if (arg instanceof Doc) {
+            return { id: arg.id }
+          }
+
+          return arg
+        }),
+        result: JSON.stringify(changedArgs),
+      },
+    }).send(pk ? true : undefined)
+
+    return changedArgs.filter((arg: any) => typeof arg === 'object')
   }
 
   doc = (id: string): Doc<T> => {

--- a/packages/client/src/Doc.ts
+++ b/packages/client/src/Doc.ts
@@ -40,7 +40,7 @@ export class Doc<T> {
     }
 
     const res = await this.client.request({
-      url: `/data/${encodeURIComponent(this.collection.id)}/${encodeURIComponent(this.id)}`,
+      url: `/collections/${encodeURIComponent(this.collection.id)}/records/${encodeURIComponent(this.id)}`,
       method: 'PUT',
       data: {
         data,
@@ -64,7 +64,7 @@ export class Doc<T> {
   }
 
   request = (): Request => ({
-    url: `/data/${encodeURIComponent(this.collection.id)}/${encodeURIComponent(this.id)}`,
+    url: `/collections/${encodeURIComponent(this.collection.id)}/records/${encodeURIComponent(this.id)}`,
     method: 'GET',
   })
 }

--- a/packages/client/src/Doc.ts
+++ b/packages/client/src/Doc.ts
@@ -6,7 +6,7 @@ import { Request, CollectionDocument } from './types'
 export type DocSnapshotRegister<T> = (d: Doc<T>, fn: SubscriptionFn<CollectionDocument<T>>, errFn?: SubscriptionErrorFn) => (() => void)
 
 export class Doc<T> {
-  private id: string
+  id: string
   private collection: Collection<T>
   private client: Client
   private onSnapshotRegister: DocSnapshotRegister<T>
@@ -40,7 +40,7 @@ export class Doc<T> {
     }
 
     const res = await this.client.request({
-      url: `/${encodeURIComponent(this.collection.id)}/${encodeURIComponent(this.id)}`,
+      url: `/data/${encodeURIComponent(this.collection.id)}/${encodeURIComponent(this.id)}`,
       method: 'PUT',
       data: {
         data,
@@ -64,7 +64,7 @@ export class Doc<T> {
   }
 
   request = (): Request => ({
-    url: `/${encodeURIComponent(this.collection.id)}/${encodeURIComponent(this.id)}`,
+    url: `/data/${encodeURIComponent(this.collection.id)}/${encodeURIComponent(this.id)}`,
     method: 'GET',
   })
 }

--- a/packages/client/src/Query.ts
+++ b/packages/client/src/Query.ts
@@ -88,7 +88,7 @@ export class Query<T> {
 
   request = (): Request => {
     return {
-      url: `/${encodeURIComponent(this.id)}`,
+      url: `/data/${encodeURIComponent(this.id)}`,
       method: 'GET',
       params: this.params,
     }

--- a/packages/client/src/Query.ts
+++ b/packages/client/src/Query.ts
@@ -88,7 +88,7 @@ export class Query<T> {
 
   request = (): Request => {
     return {
-      url: `/data/${encodeURIComponent(this.id)}`,
+      url: `/collections/${encodeURIComponent(this.id)}/records`,
       method: 'GET',
       params: this.params,
     }

--- a/packages/client/src/Spacetime.ts
+++ b/packages/client/src/Spacetime.ts
@@ -51,7 +51,7 @@ export class Spacetime {
   private createCollection = async <T>(data: CollectionMeta): Promise<Collection<T>> => {
     const id = data.id
     await this.client.request({
-      url: `/data/$collections/${encodeURIComponent(id)}`,
+      url: `/collections/$collections/records/${encodeURIComponent(id)}`,
       method: 'POST',
       data: {
         data,

--- a/packages/client/src/Spacetime.ts
+++ b/packages/client/src/Spacetime.ts
@@ -15,7 +15,7 @@ export interface SpacetimeConfig {
 }
 
 const defaultConfig = {
-  baseURL: 'https://testnet.spacetime.xyz/v0/data',
+  baseURL: 'https://testnet.spacetime.xyz/v0',
   clientId: 'spacetime@ts/client:v0',
   sender: axios,
 }
@@ -51,7 +51,7 @@ export class Spacetime {
   private createCollection = async <T>(data: CollectionMeta): Promise<Collection<T>> => {
     const id = data.id
     await this.client.request({
-      url: `/$collections/${encodeURIComponent(id)}`,
+      url: `/data/$collections/${encodeURIComponent(id)}`,
       method: 'POST',
       data: {
         data,

--- a/packages/client/src/__tests__/Collection.spec.ts
+++ b/packages/client/src/__tests__/Collection.spec.ts
@@ -167,7 +167,7 @@ test('.call() sends a call request', async () => {
 
   expect(sender).toHaveBeenCalledWith({
     ...defaultRequest,
-    url: '/call/col/setAge',
+    url: '/collections/col/functions/setAge/call',
     method: 'POST',
     data: {
       args: [

--- a/packages/client/src/__tests__/Collection.spec.ts
+++ b/packages/client/src/__tests__/Collection.spec.ts
@@ -176,12 +176,8 @@ test('.call() sends a call request', async () => {
         },
         20,
       ],
-      result: '[{"id":"id1","age":20},20]',
     },
   })
 
-  expect(result).toEqual([{
-    id: 'id1',
-    age: 20,
-  }])
+  expect(result).toEqual(undefined)
 })

--- a/packages/client/src/__tests__/Doc.spec.ts
+++ b/packages/client/src/__tests__/Doc.spec.ts
@@ -37,7 +37,7 @@ test('get request is sent to client', async () => {
   expect(sender).toHaveBeenCalledTimes(1)
   expect(sender).toHaveBeenCalledWith({
     ...defaultRequest,
-    url: '/col1/id1',
+    url: '/data/col1/id1',
     method: 'GET',
   })
 })
@@ -57,7 +57,7 @@ test('delete request is sent to client', async () => {
   expect(sender).toHaveBeenCalledTimes(1)
   expect(sender).toHaveBeenCalledWith({
     ...defaultRequest,
-    url: '/col1/id1',
+    url: '/data/col1/id1',
     method: 'DELETE',
   })
 })
@@ -65,7 +65,7 @@ test('delete request is sent to client', async () => {
 test('set request is sent to client', async () => {
   const meta = {
     code: `
-      collection Col {
+      collection col1 {
         id: string!;
         name: string;
       }
@@ -92,7 +92,7 @@ test('set request is sent to client', async () => {
   expect(sender).toHaveBeenCalledTimes(2)
   expect(sender).toHaveBeenCalledWith({
     ...defaultRequest,
-    url: '/col1/id1',
+    url: '/data/col1/id1',
     method: 'PUT',
     data: {
       data: {

--- a/packages/client/src/__tests__/Doc.spec.ts
+++ b/packages/client/src/__tests__/Doc.spec.ts
@@ -37,7 +37,7 @@ test('get request is sent to client', async () => {
   expect(sender).toHaveBeenCalledTimes(1)
   expect(sender).toHaveBeenCalledWith({
     ...defaultRequest,
-    url: '/data/col1/id1',
+    url: '/collections/col1/records/id1',
     method: 'GET',
   })
 })
@@ -57,7 +57,7 @@ test('delete request is sent to client', async () => {
   expect(sender).toHaveBeenCalledTimes(1)
   expect(sender).toHaveBeenCalledWith({
     ...defaultRequest,
-    url: '/data/col1/id1',
+    url: '/collections/col1/records/id1',
     method: 'DELETE',
   })
 })
@@ -92,7 +92,7 @@ test('set request is sent to client', async () => {
   expect(sender).toHaveBeenCalledTimes(2)
   expect(sender).toHaveBeenCalledWith({
     ...defaultRequest,
-    url: '/data/col1/id1',
+    url: '/collections/col1/records/id1',
     method: 'PUT',
     data: {
       data: {

--- a/packages/client/src/__tests__/Query.spec.ts
+++ b/packages/client/src/__tests__/Query.spec.ts
@@ -34,7 +34,7 @@ test('query is sent to client', async () => {
   expect(sender).toHaveBeenCalledTimes(1)
   expect(sender).toHaveBeenCalledWith({
     ...defaultRequest,
-    url: '/col1',
+    url: '/data/col1',
     method: 'GET',
     params: {
       limit: 100,

--- a/packages/client/src/__tests__/Query.spec.ts
+++ b/packages/client/src/__tests__/Query.spec.ts
@@ -34,7 +34,7 @@ test('query is sent to client', async () => {
   expect(sender).toHaveBeenCalledTimes(1)
   expect(sender).toHaveBeenCalledWith({
     ...defaultRequest,
-    url: '/data/col1',
+    url: '/collections/col1/records',
     method: 'GET',
     params: {
       limit: 100,

--- a/packages/client/src/__tests__/Spacetime.spec.ts
+++ b/packages/client/src/__tests__/Spacetime.spec.ts
@@ -57,7 +57,7 @@ test('creates collections from schema in namespace', async () => {
   expect(sender).toHaveBeenCalledWith({
     ...defaultRequest,
     baseURL,
-    url: '/data/$collections/test%2FCol',
+    url: '/collections/$collections/records/test%2FCol',
     method: 'POST',
     data: {
       data: {
@@ -73,7 +73,7 @@ test('creates collections from schema in namespace', async () => {
   expect(sender).toHaveBeenCalledWith({
     ...defaultRequest,
     baseURL,
-    url: '/data/$collections/test%2FCol2',
+    url: '/collections/$collections/records/test%2FCol2',
     method: 'POST',
     data: {
       data: {

--- a/packages/client/src/__tests__/Spacetime.spec.ts
+++ b/packages/client/src/__tests__/Spacetime.spec.ts
@@ -57,7 +57,7 @@ test('creates collections from schema in namespace', async () => {
   expect(sender).toHaveBeenCalledWith({
     ...defaultRequest,
     baseURL,
-    url: '/$collections/test%2FCol',
+    url: '/data/$collections/test%2FCol',
     method: 'POST',
     data: {
       data: {
@@ -73,7 +73,7 @@ test('creates collections from schema in namespace', async () => {
   expect(sender).toHaveBeenCalledWith({
     ...defaultRequest,
     baseURL,
-    url: '/$collections/test%2FCol2',
+    url: '/data/$collections/test%2FCol2',
     method: 'POST',
     data: {
       data: {

--- a/packages/client/src/__tests__/Subscription.spec.ts
+++ b/packages/client/src/__tests__/Subscription.spec.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
 
 test('sub is instance of Subscription', () => {
   const c = new Subscription({
-    url: '/col/id',
+    url: '/data/col/id',
     method: 'GET',
     params: {},
   }, client)
@@ -42,7 +42,7 @@ test('start/stop subscriber', async () => {
   })
 
   const c = new Subscription({
-    url: '/col/id',
+    url: '/data/col/id',
     method: 'GET',
     params: {},
   }, client)
@@ -80,7 +80,7 @@ test('subscriber does not error on 304', async () => {
   })
 
   const c = new Subscription({
-    url: '/col/id',
+    url: '/data/col/id',
     method: 'GET',
     params: {},
   }, client)
@@ -107,7 +107,7 @@ test('subscriber errors on error', async () => {
   })
 
   const c = new Subscription({
-    url: '/col/id',
+    url: '/data/col/id',
     method: 'GET',
     params: {},
   }, client)
@@ -125,7 +125,7 @@ test('subscriber errors on error', async () => {
 
 test('subscriber closes on unsub', () => {
   const c = new Subscription({
-    url: '/col/id',
+    url: '/data/col/id',
     method: 'GET',
     params: {},
   }, client)
@@ -140,7 +140,7 @@ test('subscriber closes on unsub', () => {
 
 test('subscriber adds/removes multiple subs', async () => {
   const c = new Subscription({
-    url: '/col/id',
+    url: '/data/col/id',
     method: 'GET',
     params: {},
   }, client)
@@ -177,7 +177,7 @@ test('subscriber adds/removes multiple subs', async () => {
 
 test('data is cached through reset', async () => {
   const c = new Subscription({
-    url: '/col/id',
+    url: '/data/col/id',
     method: 'GET',
     params: {},
   }, client)

--- a/packages/client/src/__tests__/Subscription.spec.ts
+++ b/packages/client/src/__tests__/Subscription.spec.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
 
 test('sub is instance of Subscription', () => {
   const c = new Subscription({
-    url: '/data/col/id',
+    url: '/collections/col/records/id',
     method: 'GET',
     params: {},
   }, client)
@@ -42,7 +42,7 @@ test('start/stop subscriber', async () => {
   })
 
   const c = new Subscription({
-    url: '/data/col/id',
+    url: '/collections/col/records/id',
     method: 'GET',
     params: {},
   }, client)
@@ -80,7 +80,7 @@ test('subscriber does not error on 304', async () => {
   })
 
   const c = new Subscription({
-    url: '/data/col/id',
+    url: '/collections/col/records/id',
     method: 'GET',
     params: {},
   }, client)
@@ -107,7 +107,7 @@ test('subscriber errors on error', async () => {
   })
 
   const c = new Subscription({
-    url: '/data/col/id',
+    url: '/collections/col/records/id',
     method: 'GET',
     params: {},
   }, client)
@@ -125,7 +125,7 @@ test('subscriber errors on error', async () => {
 
 test('subscriber closes on unsub', () => {
   const c = new Subscription({
-    url: '/data/col/id',
+    url: '/collections/col/records/id',
     method: 'GET',
     params: {},
   }, client)
@@ -140,7 +140,7 @@ test('subscriber closes on unsub', () => {
 
 test('subscriber adds/removes multiple subs', async () => {
   const c = new Subscription({
-    url: '/data/col/id',
+    url: '/collections/col/records/id',
     method: 'GET',
     params: {},
   }, client)
@@ -177,7 +177,7 @@ test('subscriber adds/removes multiple subs', async () => {
 
 test('data is cached through reset', async () => {
   const c = new Subscription({
-    url: '/data/col/id',
+    url: '/collections/col/records/id',
     method: 'GET',
     params: {},
   }, client)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1981,10 +1981,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@spacetimexyz/parser@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@spacetimexyz/parser/-/parser-0.1.2.tgz#1d66cd2dab52c98597c103af782dbd90c5806859"
-  integrity sha512-L+xSeuCNK7tgSwaVlkBEes+wguTQxvLUwhKHxe0aYHYhMZ9RiTNK/Fjx61VDyKEnKnfaE3rKnD/E8LpFc7tfLw==
+"@spacetimexyz/parser@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@spacetimexyz/parser/-/parser-0.1.3.tgz#63da16f4fbbecb1323d3e2e3aee13ff37e8d181a"
+  integrity sha512-7k1VSUh7oe/A0SEE/8WWTXilRVutgebtBS7BingXRlV6x/eyJO/70AU4qDJ9WDAAmE86gdK+oaCKCNFHI9d3ug==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1981,10 +1981,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@spacetimexyz/parser@0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@spacetimexyz/parser/-/parser-0.1.3.tgz#63da16f4fbbecb1323d3e2e3aee13ff37e8d181a"
-  integrity sha512-7k1VSUh7oe/A0SEE/8WWTXilRVutgebtBS7BingXRlV6x/eyJO/70AU4qDJ9WDAAmE86gdK+oaCKCNFHI9d3ug==
+"@spacetimexyz/parser@0.1.4-beta2":
+  version "0.1.4-beta2"
+  resolved "https://registry.yarnpkg.com/@spacetimexyz/parser/-/parser-0.1.4-beta2.tgz#6591f160e71afe7d56a56448be90d455f8e14a84"
+  integrity sha512-81HD2Nah5+giWn0RNxRG5B5GYGMoiNhNZyjhP/23N8xPXAO7kZOAgrgAmiCpFstsVYyZpf66bRHiGoB50drpyw==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
Depends on: https://github.com/spacetimehq/spacetime/pull/171

I stripped /data from the default base URL, because we have a new /v0/call endpoint. IMO this is better than overloading /v0/data, but I can change it if you wanna keep /v0/data as prefix for all endpoints.