### PR TITLE
Update spacetime-lang to 0.1.4

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,7 +27,7 @@
       "<rootDir>/**/*.spec.{js,jsx,ts,tsx}"
     ],
     "moduleNameMapper": {
-      "^@spacetimexyz/parser$": "@spacetimexyz/parser/node"
+      "^@spacetimexyz/lang$": "@spacetimexyz/lang/node"
     },
     "testEnvironment": "node"
   },
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@spacetimexyz/eth": "^0.1.27",
-    "@spacetimexyz/parser": "0.1.4-beta2",
+    "@spacetimexyz/lang": "^0.1.4",
     "axios": "^0.27.2",
     "lodash.merge": "^4.6.2"
   }

--- a/packages/client/src/Collection.ts
+++ b/packages/client/src/Collection.ts
@@ -3,7 +3,7 @@ import { Query } from './Query'
 import { Subscription, SubscriptionFn, SubscriptionErrorFn } from './Subscription'
 import { Client } from './Client'
 import { BasicValue, CollectionMeta, CollectionDocument, CollectionList, QueryWhereOperator } from './types'
-import { parse, Program, validateSet } from '@spacetimexyz/parser'
+import { parse, Program, validateSet } from '@spacetimexyz/lang'
 
 export class Collection<T> {
   id: string

--- a/packages/client/src/Spacetime.ts
+++ b/packages/client/src/Spacetime.ts
@@ -1,4 +1,4 @@
-import { parse } from '@spacetimexyz/parser'
+import { parse } from '@spacetimexyz/lang'
 import axios from 'axios'
 import merge from 'lodash.merge'
 import { Client } from './Client'

--- a/packages/client/webpack.config.js
+++ b/packages/client/webpack.config.js
@@ -10,7 +10,7 @@ const config = (target) => ({
   externals: [
     nodeExternals(),
     {
-      '@spacetimexyz/parser': '@spacetimexyz/parser/' + target,
+      '@spacetimexyz/lang': '@spacetimexyz/lang/' + target,
     },
   ],
   module: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1981,10 +1981,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@spacetimexyz/parser@0.1.4-beta2":
-  version "0.1.4-beta2"
-  resolved "https://registry.yarnpkg.com/@spacetimexyz/parser/-/parser-0.1.4-beta2.tgz#6591f160e71afe7d56a56448be90d455f8e14a84"
-  integrity sha512-81HD2Nah5+giWn0RNxRG5B5GYGMoiNhNZyjhP/23N8xPXAO7kZOAgrgAmiCpFstsVYyZpf66bRHiGoB50drpyw==
+"@spacetimexyz/lang@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@spacetimexyz/lang/-/lang-0.1.4.tgz#4ef6865afdf2932fa43ce094e5dece3790cdd68d"
+  integrity sha512-muGtU+CaXkgzTVG0QQHHVLfnBO0BV+UjtYNbkNLWBtnedD8mq5cfzx/84VyUyepn2/L7fgWWzuwkb1Itystyng==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
0.1.4 contains support for asc, desc identifiers, will be needed to load the schema in social.