### PR TITLE
Specify @spacetimexyz/client as a peer dependency of the react lib

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,9 +46,7 @@
     "typescript": "^4.6.4"
   },
   "peerDependencies": {
-    "react": ">=16.8"
-  },
-  "dependencies": {
-    "@spacetimexyz/client": "^0.2.0"
+    "react": ">=16.8",
+    "@spacetimexyz/client": "*"
   }
 }


### PR DESCRIPTION
Currently projects that install @spacetimexyz/react and client have to keep both of the package versions in sync, or else you get the following error:
```
❯ yarn build
yarn run v1.22.19
$ react-app-rewired build
Creating an optimized production build...
Failed to compile.

TS2322: Type 'import("/Users/dwq/Documents/spacetime/social/node_modules/@spacetimexyz/client/node/Spacetime").Spacetime' is not assignable to type 'import("/Users/dwq/Documents/spacetime/social/node_modules/@spacetimexyz/react/node_modules/@spacetimexyz/client/node/Spacetime").Spacetime'.
  Types have separate declarations of a private property 'config'.
    17 | export const App = () => {
    18 |   return (
  > 19 |     <SpacetimeProvider spacetime={spacetime}>
       |                        ^^^^^^^^^
    20 |       <AuthProvider
    21 |         domain={process.env.REACT_APP_DOMAIN}
    22 |         storagePrefix={process.env.REACT_APP_AUTH_STORAGE_PREFIX}


error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
That's when you have client 0.2.1 but react 0.2.0

Specifying client as a peer dependency of @spacetimexyz/react should fix this