### PR TITLE
fix: move pull request details from `run` to `env` vars

### DIFF
--- a/.github/workflows/release.pr.merge.yml
+++ b/.github/workflows/release.pr.merge.yml
@@ -23,12 +23,14 @@ jobs:
       - run: git config --global user.name "Polybase CI"
 
       - name: Get PR Info
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_DESC: ${{ github.event.pull_request.body }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          PR_DESC="${{ github.event.pull_request.body }}"
-          PR_BRANCH="${{ github.event.pull_request.head.ref }}"
           PR_VERSION="${PR_BRANCH#*release-}"
-  
+
           echo "PR Title: $PR_TITLE"
           echo "PR Description: $PR_DESC"
           echo "PR Branch: $PR_BRANCH"


### PR DESCRIPTION
This PR moves `PR_TITLE`, `PR_BODY` et al from the `run` section of the workflow (where it is susceptible to code injection) to the `env` section of the step.

Special thanks to: Francesco Garofalo <francesco.garofalo@goteleport.com> for pointing out the potential security issue.

Reference: https://securitylab.github.com/research/github-actions-untrusted-input/